### PR TITLE
[feat] 전역 상태에 내위치 추가

### DIFF
--- a/app/(client)/(anon)/login/page.tsx
+++ b/app/(client)/(anon)/login/page.tsx
@@ -10,6 +10,8 @@ import useUserStore from "@/store/useUserStore";
 const LoginPage = () => {
   const router = useRouter();
   const { setImg, setNickname, setIsLoggedIn } = useUserStore();
+  const userLat = useUserStore((state) => state.userLat);
+  const userLon = useUserStore((state) => state.userLon);
 
   const [formData, setFormData] = useState({
     email: "",
@@ -67,7 +69,7 @@ const LoginPage = () => {
         if (prevUrl) {
           router.push(decodeURIComponent(prevUrl));
         } else {
-          router.push("/");
+          router.push(`/spots?lat=${userLat}&lon=${userLon}`);
         }
       }
     } catch (err: unknown) {

--- a/app/(client)/(anon)/page.tsx
+++ b/app/(client)/(anon)/page.tsx
@@ -5,22 +5,25 @@ import { useRouter } from "next/navigation";
 import Image from "next/image";
 import styles from "./IndexPage.module.scss";
 import { getMyLocation } from "@/utils/getMyLocation";
-
-const DEFAULT_LAT = 37.5665;
-const DEFAULT_LON = 126.978;
+import useUserStore from "@/store/useUserStore";
 
 const IndexPage = () => {
   const router = useRouter();
+  const userLat = useUserStore((state) => state.userLat);
+  const userLon = useUserStore((state) => state.userLon);
+  const { setUserLat, setUserLon } = useUserStore();
 
   useEffect(() => {
     getMyLocation()
       .then(({ lat, lon }) => {
+        setUserLat(lat);
+        setUserLon(lon);
         router.replace(`/spots?lat=${lat}&lon=${lon}`);
       })
       .catch(() => {
-        router.replace(`/spots?lat=${DEFAULT_LAT}&lon=${DEFAULT_LON}`);
+        router.replace(`/spots?lat=${userLat}&lon=${userLon}`);
       });
-  }, [router]);
+  }, [router, userLat, userLon, setUserLat, setUserLon]);
 
   return (
     <div className={styles.indexContainer}>

--- a/app/(client)/(anon)/spots/components/BottomSheet.tsx
+++ b/app/(client)/(anon)/spots/components/BottomSheet.tsx
@@ -8,32 +8,17 @@ import { FaWonSign } from "react-icons/fa6";
 import Link from "next/link";
 import { GetSpotsDTO } from "@/application/usecases/spot/dto/GetSpotsDto";
 import Image from "next/image";
-import { getMyLocation } from "@/utils/getMyLocation";
+import useUserStore from "@/store/useUserStore";
 
 const BottomSheet = ({ spots }: { spots: GetSpotsDTO[] }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [startY, setStartY] = useState(0);
   const [translateY, setTranslateY] = useState(0);
-  const [userLat, setUserLat] = useState<number | null>(null);
-  const [userLon, setUserLon] = useState<number | null>(null);
   const [sortedSpots, setSortedSpots] = useState<GetSpotsDTO[]>(spots);
   const [selectedSort, setSelectedSort] = useState<string>("distance");
+  const userLat = useUserStore((state) => state.userLat); // 내 위치 가져오기 -> 거리계산 목적
+  const userLon = useUserStore((state) => state.userLon);
   const sheetRef = useRef<HTMLDivElement>(null);
-
-  // 내 위치 가져오기 -> 거리계산 목적
-  useEffect(() => {
-    getMyLocation()
-      .then(({ lat, lon }) => {
-        setUserLat(lat);
-        setUserLon(lon);
-      })
-      .catch((error) => {
-        console.log(error.message);
-        // 현재위치 가져오기 실패 시 디폴트값으로 설정
-        setUserLat(37.5665);
-        setUserLon(126.978);
-      });
-  }, []);
 
   useEffect(() => {
     if (spots.length === 0) {

--- a/app/(client)/(anon)/spots/components/NaverMap.tsx
+++ b/app/(client)/(anon)/spots/components/NaverMap.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { GetSpotsDTO } from "@/application/usecases/spot/dto/GetSpotsDto";
 import { useRouter } from "next/navigation";
-import { getMyLocation } from "@/utils/getMyLocation";
+import useUserStore from "@/store/useUserStore";
 
 const categoryMap: { [key: string]: string } = {
   액티비티: "activity",
@@ -27,6 +27,8 @@ const NaverMap = ({
   const markersRef = useRef<naver.maps.Marker[]>([]);
   const myLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const userLat = useUserStore((state) => state.userLat);
+  const userLon = useUserStore((state) => state.userLon);
 
   // 네이버 지도 API 로드
   useEffect(() => {
@@ -122,26 +124,18 @@ const NaverMap = ({
     }
 
     // 내 위치 가져오기
-    getMyLocation()
-      .then(({ lat: userLat, lon: userLon }) => {
-        myLocationMarkerRef.current = new window.naver.maps.Marker({
-          position: new window.naver.maps.LatLng(userLat, userLon),
-          map: mapRef.current!,
-          icon: {
-            url: "/images/bee_50x50.svg",
-            size: new window.naver.maps.Size(50, 50),
-          },
-        });
+    myLocationMarkerRef.current = new window.naver.maps.Marker({
+      position: new window.naver.maps.LatLng(userLat, userLon),
+      map: mapRef.current!,
+      icon: {
+        url: "/images/bee_50x50.svg",
+        size: new window.naver.maps.Size(50, 50),
+      },
+    });
 
-        // 지도 중심을 내 위치로 이동
-        mapRef.current?.setCenter(
-          new window.naver.maps.LatLng(userLat, userLon)
-        );
-      })
-      .catch((error) => {
-        console.log("내 위치를 가져올 수 없습니다:", error.message);
-      });
-  }, [isMapLoaded]);
+    // 지도 중심을 내 위치로 이동
+    mapRef.current?.setCenter(new window.naver.maps.LatLng(userLat, userLon));
+  }, [isMapLoaded, userLat, userLon]);
 
   return (
     <div id="map" style={{ height: "calc(100vh - 5rem)", width: "100%" }} />

--- a/app/(client)/(anon)/spots/components/SearchFilter.tsx
+++ b/app/(client)/(anon)/spots/components/SearchFilter.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { getGeocode } from "@/utils/getGeocode";
 import { getMyLocation } from "@/utils/getMyLocation";
+import useUserStore from "@/store/useUserStore";
 
 const SearchFilter = () => {
   const searchParams = useSearchParams();
@@ -19,6 +20,10 @@ const SearchFilter = () => {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isRecentVisible, setIsRecentVisible] = useState(false);
   const [tempQuery, setTempQuery] = useState(query);
+  const { setUserLat, setUserLon } = useUserStore();
+  const userLat = useUserStore((state) => state.userLat);
+  const userLon = useUserStore((state) => state.userLon);
+
   const inputRef = useRef<HTMLInputElement>(null); // 검색 input 요소 참조 추가
 
   // 로컬 스토리지에서 최근 검색어 불러오기
@@ -149,16 +154,20 @@ const SearchFilter = () => {
     try {
       const location = await getMyLocation();
       if (location) {
+        setUserLat(location.lat);
+        setUserLon(location.lon);
         updateFilters({ lat: location.lat, lon: location.lon, query: "" });
         setTempQuery("");
       } else {
         alert("현재 위치를 가져올 수 없습니다. 기본 위치로 이동합니다.");
-        updateFilters({ lat: 37.5665, lon: 126.978, query: "" });
+        updateFilters({ lat: userLat, lon: userLon, query: "" });
       }
     } catch (error) {
       console.log("위치 정보를 가져올 수 없음:", error);
-      alert("현재 위치를 가져올 수 없습니다. 기본 위치로 이동합니다.");
-      updateFilters({ lat: 37.5665, lon: 126.978, query: "" });
+      alert(
+        "현재 위치를 가져올 수 없습니다. 기본 위치(서울시청)로 이동합니다."
+      );
+      updateFilters({ lat: userLat, lon: userLon, query: "" });
     }
   };
 

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -14,11 +14,13 @@ const Header = () => {
   const pathname = usePathname();
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
   const clearInfo = useUserStore((state) => state.clearInfo);
+  const userLat = useUserStore((state) => state.userLat);
+  const userLon = useUserStore((state) => state.userLon);
 
   // 헤더 타입 결정
-  let type: "default" | "back" | "mypage" | null = "default";
+  let type: "logo" | "back" | "mypage" | null = "logo";
   if (pathname === "/spots" || pathname === "/login") {
-    type = "default"; // 로고헤더
+    type = "logo"; // 로고헤더
   } else if (pathname.startsWith("/user")) {
     type = "mypage"; // 마이페이지 헤더
   } else if (pathname === "/") {
@@ -50,7 +52,7 @@ const Header = () => {
       document.cookie =
         "prevUrl=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
       setMenuOpen(false);
-      router.push("/");
+      router.push(`/spots?lat=${userLat}&lon=${userLon}`);
     } catch (error) {
       console.log("로그아웃 에러:", error);
     }
@@ -75,7 +77,7 @@ const Header = () => {
       document.cookie =
         "prevUrl=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
       setMenuOpen(false);
-      router.push("/");
+      router.push(`/spots?lat=${userLat}&lon=${userLon}`);
     } catch (error) {
       console.log("회원탈퇴 에러:", error);
     }
@@ -83,9 +85,12 @@ const Header = () => {
 
   return (
     <header className={styles.headerContainer}>
-      {(type === "default" || type === "mypage") && (
+      {(type === "logo" || type === "mypage") && (
         <div className={styles.wrapper}>
-          <div className={styles.logo} onClick={() => router.push("/spots")}>
+          <div
+            className={styles.logo}
+            onClick={() => router.push(`/spots?lat=${userLat}&lon=${userLon}`)}
+          >
             <Image
               width="100"
               height="54"
@@ -94,7 +99,7 @@ const Header = () => {
               priority
             />
           </div>
-          {type === "default" ? (
+          {type === "logo" ? (
             <div
               className={styles.menu}
               onClick={() =>

--- a/store/useUserStore.ts
+++ b/store/useUserStore.ts
@@ -5,9 +5,13 @@ type UserStore = {
   img: string | null;
   nickname: string | null;
   isLoggedIn: boolean;
+  userLat: number;
+  userLon: number;
   setImg: (img: string) => void;
   setNickname: (nickname: string) => void;
   setIsLoggedIn: (loggedIn: boolean) => void;
+  setUserLat: (lat: number) => void;
+  setUserLon: (lon: number) => void;
   clearInfo: () => void;
 };
 
@@ -17,9 +21,13 @@ const useUserStore = create<UserStore>()(
       img: null,
       nickname: null,
       isLoggedIn: false,
+      userLat: 37.5665,
+      userLon: 126.978,
       setImg: (img) => set({ img }),
       setNickname: (nickname) => set({ nickname }),
       setIsLoggedIn: (loggedIn) => set({ isLoggedIn: loggedIn }),
+      setUserLat: (lat) => set({ userLat: lat }),
+      setUserLon: (lon) => set({ userLon: lon }),
       clearInfo: () => set({ img: null, nickname: null, isLoggedIn: false }),
     }),
     {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 작업
- [ ] 디자인 작업
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

- <br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 초기페이지에서 받은 내위치를 zustand 스토어에 저장
- 지도에서 내위치 업데이트시 스토어에 저장 -> 내위치 쓰이는 곳에 활용(각 컴포넌트에서 내위치 불러오던 함수 제거)
- 바텀시트, 네이버맵에서 각자 내위치를 불러오는 횟수를 줄임으로써 렌더링시간 감소