### PR TITLE
[style] root container 높이 100vh->100dvh로 변경

### DIFF
--- a/app/(client)/(anon)/spots/components/NaverMap.module.scss
+++ b/app/(client)/(anon)/spots/components/NaverMap.module.scss
@@ -1,13 +1,12 @@
 .mapContainer {
-  position: relative;
-  height: calc(100vh - 5rem);
+  height: 100%;
   width: 100%;
   .mapElement {
     height: 100%;
     width: 100%;
   }
   .searchButton {
-    position: absolute;
+    position: fixed;
     bottom: 10vh;
     left: 50%;
     transform: translateX(-50%);

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,7 +197,7 @@ input {
   flex-direction: column;
   max-width: 30rem;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   margin: 0 auto;
   background-color: var(--background-color);
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능 작업
- [x] 디자인 작업
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

- <br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 모바일 환경에서 100vh로 했을 때 주소 표시줄에 따라 스크롤이 생기는 현상 발견
- dvh(dvh: Dynamic Viewport Height) 단위를 써서 해결
- "이 지역에서 검색"버튼 absolute -> fixed로 변경
